### PR TITLE
Call kOfxMeshEffectActionIsIdentity before cooking

### DIFF
--- a/intern/openmesheffect/blender/intern/mfxConvert.cpp
+++ b/intern/openmesheffect/blender/intern/mfxConvert.cpp
@@ -20,6 +20,7 @@
 #include "mfxHost.h"
 
 #include <iostream>
+#include <cstring>
 
 void copy_parameter_value_from_rna(OfxParamHandle param, const OpenMeshEffectParameterInfo *rna)
 {

--- a/intern/openmesheffect/blender/intern/mfxModifier.cpp
+++ b/intern/openmesheffect/blender/intern/mfxModifier.cpp
@@ -182,6 +182,17 @@ Mesh * mfx_Modifier_do(OpenMeshEffectModifierData *fxmd, Mesh *mesh)
   // Get parameters
   runtime->get_parameters_from_rna(fxmd);
 
+  // Test if we can skip cooking
+  OfxPlugin *plugin = runtime->registry->plugins[runtime->effect_index];
+  bool shouldCook = true;
+  ofxhost_is_identity(plugin, runtime->effect_instance, &shouldCook);
+
+  if (false == shouldCook) {
+    printf("effect is identity, skipping cooking\n");
+    printf("==/ mfx_Modifier_do\n");
+    return mesh;
+  }
+
   // Set input mesh data binding, used by before/after callbacks
   MeshInternalData input_data;
   input_data.is_input = true;
@@ -196,7 +207,6 @@ Mesh * mfx_Modifier_do(OpenMeshEffectModifierData *fxmd, Mesh *mesh)
   output_data.source_mesh = mesh;
   propertySuite->propSetPointer(&output->mesh.properties, kOfxMeshPropInternalData, 0, (void*)&output_data);
 
-  OfxPlugin *plugin = runtime->registry->plugins[runtime->effect_index];
   ofxhost_cook(plugin, runtime->effect_instance);
 
   // Free mesh on Blender side

--- a/intern/openmesheffect/host/mfxHost.c
+++ b/intern/openmesheffect/host/mfxHost.c
@@ -262,6 +262,44 @@ bool ofxhost_cook(OfxPlugin *plugin, OfxMeshEffectHandle effectInstance) {
   return true;
 }
 
+bool ofxhost_is_identity(OfxPlugin *plugin, OfxMeshEffectHandle effectInstance, bool *shouldCook) {
+  OfxStatus status;
+
+  OfxPropertySetStruct inArgs, outArgs;
+  init_properties(&inArgs);
+  init_properties(&outArgs);
+
+  propSetInt(&inArgs, kOfxPropTime, 0, 0);
+  propSetString(&outArgs, kOfxPropName, 0, "");
+  propSetInt(&outArgs, kOfxPropTime, 0, 0);
+
+  *shouldCook = true;
+
+  status = plugin->mainEntry(kOfxMeshEffectActionIsIdentity, effectInstance, &inArgs, &outArgs);
+  printf("%s action returned status %d (%s)\n", kOfxMeshEffectActionIsIdentity, status, getOfxStateName(status));
+
+  free_properties(&inArgs);
+  free_properties(&outArgs);
+
+  if (kOfxStatErrMemory == status) {
+    printf("ERROR: Not enough memory for plug-in '%s'.\n", plugin->pluginIdentifier);
+    return false;
+  }
+  if (kOfxStatFailed == status) {
+    printf("ERROR: Error while cooking an instance of plug-in '%s'.\n", plugin->pluginIdentifier); // see message
+    return false;
+  }
+  if (kOfxStatErrFatal == status) {
+    printf("ERROR: Fatal error while cooking an instance of plug-in '%s'.\n", plugin->pluginIdentifier);
+    return false;
+  }
+  if (kOfxStatOK == status) {
+    *shouldCook = false;
+    return true;
+  }
+  return true;
+}
+
 bool use_plugin(const PluginRegistry *registry, int plugin_index) {
   OfxPlugin *plugin = registry->plugins[plugin_index];
   printf("Using plugin #%d: %s\n", plugin_index, plugin->pluginIdentifier);

--- a/intern/openmesheffect/host/mfxHost.h
+++ b/intern/openmesheffect/host/mfxHost.h
@@ -49,6 +49,7 @@ void ofxhost_release_descriptor(OfxMeshEffectHandle effectDescriptor);
 bool ofxhost_create_instance(OfxPlugin *plugin, OfxMeshEffectHandle effectDescriptor, OfxMeshEffectHandle *effectInstance);
 void ofxhost_destroy_instance(OfxPlugin *plugin, OfxMeshEffectHandle effectInstance);
 bool ofxhost_cook(OfxPlugin *plugin, OfxMeshEffectHandle effectInstance);
+bool ofxhost_is_identity(OfxPlugin *plugin, OfxMeshEffectHandle effectInstance, bool *shouldCook);
 
 #include "mfxPluginRegistry.h"
 // TODO: use_plugin might be dropped from API


### PR DESCRIPTION
Hi, I recently implemented `IsIdentity` action for MfxVTK ( https://github.com/tkarabela/MfxVTK/commit/bfd383afcce00a2a7d5178bd25039a57b6324478 ), it's available in MfxVTK 0.3.0. This is the code needed to support it in Blender OFX host.