### PR TITLE
Fix `kOfxMeshPropTransformMatrix`

### DIFF
--- a/intern/openmesheffect/blender/intern/mfxCallbacks.cpp
+++ b/intern/openmesheffect/blender/intern/mfxCallbacks.cpp
@@ -660,12 +660,13 @@ void Converter::propSetTransformMatrix(OfxPropertySetHandle properties, const Ob
   assert(NULL != object);
   double *matrix = new double[16];
 
-#pragma omp parallel for
+// #pragma omp parallel for
   for (int i = 0; i < 16; ++i) {
-    matrix[i] = static_cast<double>(object->obmat[i / 4][i % 4]);
+    // convert to OpenMeshEffect's row-major order from Blender's column-major
+    matrix[i] = static_cast<double>(object->obmat[i % 4][i / 4]);
   }
 
-  MFX_CHECK(ps->propSetPointer(properties, kOfxMeshPropTransformMatrix, 0, (void **)&matrix));
+  MFX_CHECK(ps->propSetPointer(properties, kOfxMeshPropTransformMatrix, 0, (void *)matrix));
 }
 
 void Converter::propFreeTransformMatrix(OfxPropertySetHandle properties) const

--- a/intern/openmesheffect/host/intern/properties.cpp
+++ b/intern/openmesheffect/host/intern/properties.cpp
@@ -157,6 +157,7 @@ bool OfxPropertySetStruct::check_property_context(PropertySetContext context, Pr
       (0 == strcmp(property, kOfxMeshPropFaceCount)    && type == PROP_TYPE_INT)     ||
       (0 == strcmp(property, kOfxMeshPropNoLooseEdge)  && type == PROP_TYPE_INT)     ||
       (0 == strcmp(property, kOfxMeshPropConstantFaceCount) && type == PROP_TYPE_INT) ||
+      (0 == strcmp(property, kOfxMeshPropTransformMatrix) && type == PROP_TYPE_POINTER) ||
       false
     );
     case PropertySetContext::Param:


### PR DESCRIPTION
- Blender uses column-major matrix storage (see eg. `mul_v3_m3v3()` in `math_matrix.c` or https://wiki.blender.jp/Dev:Source/Mathematics/Math_Library), we need to convert this to row-major for OFX.
- Fixed `MFX_CHECK()` not recognizing `kOfxMeshPropTransformMatrix`.

With this patch, I'm getting the expected matrix on plugin side:
![Screenshot from 2020-11-10 00-31-46](https://user-images.githubusercontent.com/8166544/98609487-a5409a00-22ed-11eb-832b-b1e0ee14d665.png)
