### PR TITLE
Handle kOfxMeshPropAttributeCount, kOfxPropLabel

### DIFF
--- a/intern/openmesheffect/blender/intern/mfxRuntime.cpp
+++ b/intern/openmesheffect/blender/intern/mfxRuntime.cpp
@@ -315,11 +315,19 @@ void OpenMeshEffectRuntime::reload_parameter_info(OpenMeshEffectModifierData *fx
     const OfxPropertySetStruct & props = parameters->parameters[i]->properties;
     OpenMeshEffectParameterInfo &rna = fxmd->parameter_info[i];
 
-    int prop_idx = props.find_property(kOfxParamPropScriptName);
-    const char *system_name = prop_idx != -1 ? props.properties[prop_idx]->value->as_const_char :
-                                               parameters->parameters[i]->name;
+    int script_name_idx = props.find_property(kOfxParamPropScriptName);
+    int label_idx = props.find_property(kOfxPropLabel);
+
+    const char *parameter_name = parameters->parameters[i]->name;
+    const char *system_name = (script_name_idx != -1) ?
+                                  props.properties[script_name_idx]->value->as_const_char :
+                                  parameter_name;
+    const char *label_name = (label_idx != -1) ?
+                                  props.properties[label_idx]->value->as_const_char :
+                                  parameter_name;
+
     strncpy(rna.name, system_name, sizeof(rna.name));
-    strncpy(rna.label, parameters->parameters[i]->name, sizeof(rna.label));
+    strncpy(rna.label, label_name, sizeof(rna.label));
     rna.type = static_cast<int>(parameters->parameters[i]->type);
 
     int default_idx = props.find_property(kOfxParamPropDefault);

--- a/intern/openmesheffect/host/intern/meshEffectSuite.cpp
+++ b/intern/openmesheffect/host/intern/meshEffectSuite.cpp
@@ -164,6 +164,7 @@ OfxStatus inputGetMesh(OfxMeshInputHandle input,
   propSetInt(inputMeshProperties, kOfxMeshPropPointCount, 0, 0);
   propSetInt(inputMeshProperties, kOfxMeshPropVertexCount, 0, 0);
   propSetInt(inputMeshProperties, kOfxMeshPropFaceCount, 0, 0);
+  propSetInt(inputMeshProperties, kOfxMeshPropAttributeCount, 0, 0);
 
   // Default attributes
   attributeDefine(inputMeshHandle,
@@ -279,6 +280,10 @@ OfxStatus attributeDefine(OfxMeshHandle meshHandle,
   propSetString(attributeProperties, kOfxMeshAttribPropType, 0, type);
   propSetString(attributeProperties, kOfxMeshAttribPropSemantic, 0, semantic);
   propSetInt(attributeProperties, kOfxMeshAttribPropIsOwner, 0, 1);
+
+  // Keep attribute count up-to-date
+  propSetInt(
+      &meshHandle->properties, kOfxMeshPropAttributeCount, 0, meshHandle->attributes.num_attributes);
 
   if (attributeHandle) {
     *attributeHandle = attributeProperties;

--- a/intern/openmesheffect/host/intern/properties.cpp
+++ b/intern/openmesheffect/host/intern/properties.cpp
@@ -158,6 +158,7 @@ bool OfxPropertySetStruct::check_property_context(PropertySetContext context, Pr
       (0 == strcmp(property, kOfxMeshPropNoLooseEdge)  && type == PROP_TYPE_INT)     ||
       (0 == strcmp(property, kOfxMeshPropConstantFaceCount) && type == PROP_TYPE_INT) ||
       (0 == strcmp(property, kOfxMeshPropTransformMatrix) && type == PROP_TYPE_POINTER) ||
+      (0 == strcmp(property, kOfxMeshPropAttributeCount) && type == PROP_TYPE_INT) ||
       false
     );
     case PropertySetContext::Param:


### PR DESCRIPTION
- automatic bookkeeping of `kOfxMeshPropAttributeCount`, incremented when attribute is added (btw, it looks like adding the same attribute multiple times is not an error - not sure if it should be?)
- show `kOfxPropLabel` for effect parameters - it's in the C++ API and I call it in MfxVTK, I was wondering why it was not showing :)